### PR TITLE
removed unnecessary migration file

### DIFF
--- a/db/migrate/20111004043056_add_private_to_tweets.rb
+++ b/db/migrate/20111004043056_add_private_to_tweets.rb
@@ -1,5 +1,0 @@
-class AddPrivateToTweets < ActiveRecord::Migration
-  def change
-    add_column :tweets, :private, :boolean
-  end
-end


### PR DESCRIPTION
bug: 

rake aborted!
Multiple migrations have the version number 20111004043056

20111004043056_add_private_to_tweets.rb

this file unnecessary
