### PR TITLE
Fix for error "undefined method `name' for nil:NilClass):" when you c…

### DIFF
--- a/app/views/zombies/show.html.erb
+++ b/app/views/zombies/show.html.erb
@@ -2,7 +2,7 @@
 
 <%= render @zombie.weapons %>
 
-<p><%= pluralize(@zombie.tweets.size, "Tweet") %></p> 
+<p><%= pluralize(@zombie.tweets.count, "Tweet") %></p> 
 
 <p><%= link_to "Create a new Tweet for #{@zombie.name}", new_zombie_tweet_path(@zombie) %></p>
 <p><%= link_to "Back to Zombies", zombies_path %></p>


### PR DESCRIPTION
…lick on a zombie link.

This is the error I got with Ruby 2.2.2 Rails 3.1.1:

 Completed 500 Internal Server Error in 54ms

ActionView::Template::Error (undefined method `name' for nil:NilClass):
    2: 
    3: <%= render @zombie.weapons %>
    4: 
    5: <p><%= pluralize(@zombie.tweets.size, "Tweet") %></p> 
    6: 
    7: <p><%= link_to "Create a new Tweet for #{@zombie.name}", new_zombie_tweet_path(@zombie) %></p>
    8: <p><%= link_to "Back to Zombies", zombies_path %></p>
  app/views/zombies/show.html.erb:5:in `_app_views_zombies_show_html_erb___2202604193950842130_70315403787960' 

Keep up the good work, I love your stuff!